### PR TITLE
Combining Rod Damping and improving input file format

### DIFF
--- a/modules/moordyn/src/MoorDyn.f90
+++ b/modules/moordyn/src/MoorDyn.f90
@@ -742,22 +742,10 @@ CONTAINS
                        RETURN
                    END IF
                    
-                   ! parse out entries: Name  Diam MassDen Cd  Ca  CdEnd  CaEnd  Blin
+                   ! parse out entries: Name  Diam MassDen Cd  Ca  CdEnd  CaEnd
                    IF (ErrStat2 == 0) THEN
                       READ(Line,*,IOSTAT=ErrStat2) m%RodTypeList(l)%name, m%RodTypeList(l)%d, m%RodTypeList(l)%w, &
-                         m%RodTypeList(l)%Cdn, m%RodTypeList(l)%Can, m%RodTypeList(l)%CdEnd, m%RodTypeList(l)%CaEnd,&
-                         m%RodTypeList(l)%Blin    ! Linear damping coefficient
-
-                      if (ErrStat2 == 0) then
-                          m%RodTypeList(l)%isBlin = .TRUE.     ! linear damping was read
-                      else    ! Linear damping not present, so reread the line without it
-                          READ(Line,*,IOSTAT=ErrStat2) m%RodTypeList(l)%name, m%RodTypeList(l)%d, m%RodTypeList(l)%w, &
-                          m%RodTypeList(l)%Cdn, m%RodTypeList(l)%Can, m%RodTypeList(l)%CdEnd, m%RodTypeList(l)%CaEnd
-
-                          m%RodTypeList(l)%Blin = 0.0
-                          m%RodTypeList(l)%isBlin = .FALSE. 
-                      end if
-
+                         m%RodTypeList(l)%Cdn, m%RodTypeList(l)%Can, m%RodTypeList(l)%CdEnd, m%RodTypeList(l)%CaEnd
 
                       m%RodTypeList(l)%Cdt = 0.0_DbKi ! not used
                       m%RodTypeList(l)%Cat = 0.0_DbKi ! not used
@@ -1619,17 +1607,83 @@ CONTAINS
                   !read into a line
                   Line = NextLine(i)
 
-                  IF ( CountWords( Line ) /= 5) THEN
+                  IF ( CountWords( Line ) /= 6) THEN
                       CALL SetErrStat( ErrID_Fatal, ' Unable to parse External Load '//trim(Num2LStr(l))//' on row '//trim(Num2LStr(i))//' in input file. Row has wrong number of columns. Must be 5 columns.', ErrStat, ErrMsg, RoutineName )
                       CALL CleanUp()
                       RETURN
                   END IF
 
                   IF (ErrStat2 == 0) THEN
-                     READ(Line,*,IOSTAT=ErrStat2) m%ExtLdList(l)%IdNum, tempString1, tempString2, tempString3, tempString4
-                        
+                     READ(Line,*,IOSTAT=ErrStat2) m%ExtLdList(l)%IdNum, tempString1, tempString2, tempString3, tempString4, tempString5
+                     
+                     ! read in object type
                      CALL Conv2UC(tempString1) ! convert to uppercase so that matching is not case-sensitive
-                     CALL DecomposeString(tempString1, let1, num1, let2, num2, let3)
+                     CALL DecomposeString(tempString1, let1, num1, let2, num2, let3) 
+
+                     ! TODO: read in local or global 
+                     CALL Conv2UC(tempString5) ! convert to uppercase so that matching is not case-sensitive
+                     ! if length of tempstring5 > 1 throw error
+                     ! if tempString5 == L set local flag
+                     ! elseif tempstring 5 == G set global flag
+                     ! else throw error
+
+                     ! process translational force
+                     CALL SplitByBars(tempString2, N, tempStrings)
+                     if (N==1) then ! one force provided. Used for all force directions (useful for when force is zero)
+                        READ(tempStrings(1), *) m%ExtLdList(l)%Fext(1)
+                        m%ExtLdList(l)%Fext(2) = m%ExtLdList(l)%Fext(1)
+                        m%ExtLdList(l)%Fext(3) = m%ExtLdList(l)%Fext(1)
+                     elseif (N==3) then ! all three forces provided. Note rod forces will be applied to end A.
+                        READ(tempStrings(1), *) m%ExtLdList(l)%Fext(1)
+                        READ(tempStrings(2), *) m%ExtLdList(l)%Fext(2)
+                        READ(tempStrings(3), *) m%ExtLdList(l)%Fext(3)
+                     else
+                        CALL SetErrStat( ErrID_Fatal, 'External load entry '//trim(Num2LStr(m%ExtLdList(l)%IdNum))//' Force entry must have 3 numbers.' , ErrStat, ErrMsg, RoutineName )
+                     end if
+
+                     ! process linear damping coefficient
+                     CALL SplitByBars(tempString4, N, tempStrings)
+                     if (N == 1) then                                   ! if only one entry, use it for all directions
+                        READ(tempString4, *) m%ExtLdList(l)%Blin(1)
+                        m%ExtLdList(l)%Blin(2) = m%ExtLdList(l)%Blin(1)
+                        m%ExtLdList(l)%Blin(3) = m%ExtLdList(l)%Blin(1)
+                     else if ((N==2) .and. (let1 == "ROD")) then                                ! two directions provided, this is for rods
+                        READ(tempStrings(1), *) m%ExtLdList(l)%Blin(1)
+                        READ(tempStrings(2), *) m%ExtLdList(l)%Blin(2)
+                        m%ExtLdList(l)%Blin(3) = 0.0_DbKi 
+                     else if ((N==3) .and. (let1 /= "ROD")) then                                ! all three directions provided, not rods
+                        READ(tempStrings(1), *) m%ExtLdList(l)%Blin(1)
+                        READ(tempStrings(2), *) m%ExtLdList(l)%Blin(2)
+                        READ(tempStrings(3), *) m%ExtLdList(l)%Blin(3)
+                     else
+                        CALL SetErrStat( ErrID_Fatal, 'External load entry '//trim(Num2LStr(m%ExtLdList(l)%IdNum))//' Blin entry must have 1 or 3 numbers for non-rod objects and 1 or 2 entries for rod objects.' , ErrStat, ErrMsg, RoutineName )
+                     end if
+
+                     ! process quadratic damping coefficient
+                     CALL SplitByBars(tempString4, N, tempStrings)
+                     if (N == 1) then                                   ! if only one entry, use it for all directions
+                        READ(tempString4, *) m%ExtLdList(l)%Bquad(1)
+                        m%ExtLdList(l)%Bquad(2) = m%ExtLdList(l)%Bquad(1)
+                        m%ExtLdList(l)%Bquad(3) = m%ExtLdList(l)%Bquad(1)
+                     else if ((N==2) .and. (let1 == "ROD")) then                                ! two directions provided, this is for rods
+                        READ(tempStrings(1), *) m%ExtLdList(l)%Bquad(1)
+                        READ(tempStrings(2), *) m%ExtLdList(l)%Bquad(2)
+                        m%ExtLdList(l)%Bquad(3) = 0.0_DbKi 
+                     else if ((N==3) .and. (let1 /= "ROD")) then                                ! all three directions provided, not rods
+                        READ(tempStrings(1), *) m%ExtLdList(l)%Bquad(1)
+                        READ(tempStrings(2), *) m%ExtLdList(l)%Bquad(2)
+                        READ(tempStrings(3), *) m%ExtLdList(l)%Bquad(3)
+                     else
+                        CALL SetErrStat( ErrID_Fatal, 'External load entry '//trim(Num2LStr(m%ExtLdList(l)%IdNum))//' Bquad entry must have 1 or 3 numbers for non-rod objects and 1 or 2 entries for rod objects.' , ErrStat, ErrMsg, RoutineName )
+                     end if
+
+                     IF ( (m%ExtLdList(l)%Blin(1)<0.0) .OR. (m%ExtLdList(l)%Blin(2)<0.0) .OR. (m%ExtLdList(l)%Blin(3)<0.0) .OR. &
+                          (m%ExtLdList(l)%Bquad(1)<0.0) .OR. (m%ExtLdList(l)%Bquad(2)<0.0) .OR. (m%ExtLdList(l)%Bquad(3)<0.0) ) THEN
+                         CALL SetErrStat( ErrID_Fatal, ' Unable to parse External Load '//trim(Num2LStr(l))//' on row '//trim(Num2LStr(i))//' in input file. Damping coefficients must be non-negative.', ErrStat, ErrMsg, RoutineName )
+                         CALL CleanUp()
+                         RETURN
+                     END IF
+
                      IF (let1 == "BODY") THEN
                          IF (len_trim(num1) > 0) THEN
                             READ(num1, *) J   ! convert to int, representing parent body index
@@ -1645,59 +1699,32 @@ CONTAINS
                             CALL SetErrStat( ErrID_Fatal,  "No number provided for External Load "//trim(Num2LStr(l))//" Body attachment.", ErrStat, ErrMsg, RoutineName )
                                return
                          END IF
+                     ELSEIF (let1 == "ROD") THEN
+                        IF (len_trim(num1) > 0) THEN
+                           READ(num1, *) J   ! convert to int, representing parent rod index
+                           IF ((J <= p%nRods) .and. (J > 0)) THEN
+                              m%RodList(J)%FextU = m%RodList(J)%FextU + m%ExtLdList(l)%Fext
+                              m%RodList(J)%Blin = m%RodList(J)%Blin(1:2) + m%ExtLdList(l)%Blin(1:2) ! rods only have axial and transverse
+                              m%RodList(J)%Bquad = m%RodList(J)%Bquad(1:2) + m%ExtLdList(l)%Bquad(1:2) ! rods only have axial and transverse
+                           ELSE
+                              CALL SetErrStat( ErrID_Fatal,  "Rod ID out of bounds for External Load "//trim(Num2LStr(l))//".", ErrStat, ErrMsg, RoutineName )
+                              return
+                           END IF
+                        ELSE
+                           CALL SetErrStat( ErrID_Fatal,  "No number provided for External Load "//trim(Num2LStr(l))//" Rod attachment.", ErrStat, ErrMsg, RoutineName )
+                              return
+                        END IF
                      ELSE
-                         CALL SetErrStat( ErrID_Fatal, ' Unable to parse External Load '//trim(Num2LStr(l))//' on row '//trim(Num2LStr(i))//' in input file. External load can only be applied to bodies at the moment.', ErrStat, ErrMsg, RoutineName )
+                         CALL SetErrStat( ErrID_Fatal, ' Unable to parse External Load '//trim(Num2LStr(l))//' on row '//trim(Num2LStr(i))//' in input file. External load can only be applied to bodies or rods at the moment.', ErrStat, ErrMsg, RoutineName )
                          CALL CleanUp()
                          RETURN
                      END IF
                      
-                     ! process translational force
-                     CALL SplitByBars(tempString2, N, tempStrings)
-                     if (N==3) then ! all three forces provided
-                        READ(tempStrings(1), *) m%ExtLdList(l)%Fext(1)
-                        READ(tempStrings(2), *) m%ExtLdList(l)%Fext(2)
-                        READ(tempStrings(3), *) m%ExtLdList(l)%Fext(3)
-                     else
-                        CALL SetErrStat( ErrID_Fatal, 'External load entry '//trim(Num2LStr(m%ExtLdList(l)%IdNum))//' Force entry must have 3 numbers.' , ErrStat, ErrMsg, RoutineName )
-                     end if
-
-                     ! process linear damping coefficient
-                     CALL SplitByBars(tempString3, N, tempStrings)
-                     if (N == 1) then                                   ! if only one entry, use it for all directions
-                        READ(tempString3, *) m%ExtLdList(l)%Blin(1)
-                        m%ExtLdList(l)%Blin(2) = m%ExtLdList(l)%Blin(1)
-                        m%ExtLdList(l)%Blin(3) = m%ExtLdList(l)%Blin(1)
-                     else if (N==3) then                                ! all three directions provided
-                        READ(tempStrings(1), *) m%ExtLdList(l)%Blin(1)
-                        READ(tempStrings(2), *) m%ExtLdList(l)%Blin(2)
-                        READ(tempStrings(3), *) m%ExtLdList(l)%Blin(3)
-                     else
-                        CALL SetErrStat( ErrID_Fatal, 'External load entry '//trim(Num2LStr(m%ExtLdList(l)%IdNum))//' Blin entry must have 1 or 3 numbers.' , ErrStat, ErrMsg, RoutineName )
-                     end if
-
-                     ! process quadratic damping coefficient
-                     CALL SplitByBars(tempString4, N, tempStrings)
-                     if (N == 1) then                                   ! if only one entry, use it for all directions
-                        READ(tempString4, *) m%ExtLdList(l)%Bquad(1)
-                        m%ExtLdList(l)%Bquad(2) = m%ExtLdList(l)%Bquad(1)
-                        m%ExtLdList(l)%Bquad(3) = m%ExtLdList(l)%Bquad(1)
-                     else if (N==3) then                                ! all three directions provided
-                        READ(tempStrings(1), *) m%ExtLdList(l)%Bquad(1)
-                        READ(tempStrings(2), *) m%ExtLdList(l)%Bquad(2)
-                        READ(tempStrings(3), *) m%ExtLdList(l)%Bquad(3)
-                     else
-                        CALL SetErrStat( ErrID_Fatal, 'External load entry '//trim(Num2LStr(m%ExtLdList(l)%IdNum))//' Bquad entry must have 1 or 3 numbers.' , ErrStat, ErrMsg, RoutineName )
-                     end if
-
-                     IF ( (m%ExtLdList(l)%Blin(1)<0.0) .OR. (m%ExtLdList(l)%Blin(2)<0.0) .OR. (m%ExtLdList(l)%Blin(3)<0.0) .OR. &
-                          (m%ExtLdList(l)%Bquad(1)<0.0) .OR. (m%ExtLdList(l)%Bquad(2)<0.0) .OR. (m%ExtLdList(l)%Bquad(3)<0.0) ) THEN
-                         CALL SetErrStat( ErrID_Fatal, ' Unable to parse External Load '//trim(Num2LStr(l))//' on row '//trim(Num2LStr(i))//' in input file. Damping coefficients must be non-negative.', ErrStat, ErrMsg, RoutineName )
-                         CALL CleanUp()
-                         RETURN
-                     END IF
                   END IF
 
                END DO
+
+               ! TODO: write inputs to log file
 
             !-------------------------------------------------------------------------------------------
             else if (INDEX(Line, "CONTROL") > 0) then ! if control inputs header

--- a/modules/moordyn/src/MoorDyn.f90
+++ b/modules/moordyn/src/MoorDyn.f90
@@ -477,6 +477,8 @@ CONTAINS
                      read (OptValue,*) p%inertialF
                   else if ( OptString == 'INERTIALF_RAMPT') then
                      read (OptValue,*) p%inertialF_rampT
+                  else if ( OptString == 'OUTSWITCH') then
+                     read (OptValue,*) p%OutSwitch
                   else
                      CALL SetErrStat( ErrID_Warn, 'Unable to interpret input '//trim(OptString)//' in OPTIONS section.', ErrStat, ErrMsg, RoutineName )
                   end if
@@ -1616,6 +1618,8 @@ CONTAINS
                   IF (ErrStat2 == 0) THEN
                      READ(Line,*,IOSTAT=ErrStat2) m%ExtLdList(l)%IdNum, tempString1, tempString2, tempString3, tempString4, tempString5
                      
+                     ! TODO: check for repeat IdNum's
+
                      ! read in object type
                      CALL Conv2UC(tempString1) ! convert to uppercase so that matching is not case-sensitive
                      CALL DecomposeString(tempString1, let1, num1, let2, num2, let3) 

--- a/modules/moordyn/src/MoorDyn.f90
+++ b/modules/moordyn/src/MoorDyn.f90
@@ -742,20 +742,20 @@ CONTAINS
                        RETURN
                    END IF
                    
-                   ! parse out entries: Name  Diam MassDen Cd  Ca  CdEnd  CaEnd  LinDamp
+                   ! parse out entries: Name  Diam MassDen Cd  Ca  CdEnd  CaEnd  Blin
                    IF (ErrStat2 == 0) THEN
                       READ(Line,*,IOSTAT=ErrStat2) m%RodTypeList(l)%name, m%RodTypeList(l)%d, m%RodTypeList(l)%w, &
                          m%RodTypeList(l)%Cdn, m%RodTypeList(l)%Can, m%RodTypeList(l)%CdEnd, m%RodTypeList(l)%CaEnd,&
-                         m%RodTypeList(l)%LinDamp    ! Linear damping coefficient
+                         m%RodTypeList(l)%Blin    ! Linear damping coefficient
 
                       if (ErrStat2 == 0) then
-                          m%RodTypeList(l)%isLinDamp = .TRUE.     ! linear damping was read
+                          m%RodTypeList(l)%isBlin = .TRUE.     ! linear damping was read
                       else    ! Linear damping not present, so reread the line without it
                           READ(Line,*,IOSTAT=ErrStat2) m%RodTypeList(l)%name, m%RodTypeList(l)%d, m%RodTypeList(l)%w, &
                           m%RodTypeList(l)%Cdn, m%RodTypeList(l)%Can, m%RodTypeList(l)%CdEnd, m%RodTypeList(l)%CaEnd
 
-                          m%RodTypeList(l)%LinDamp = 0.0
-                          m%RodTypeList(l)%isLinDamp = .FALSE. 
+                          m%RodTypeList(l)%Blin = 0.0
+                          m%RodTypeList(l)%isBlin = .FALSE. 
                       end if
 
 

--- a/modules/moordyn/src/MoorDyn.f90
+++ b/modules/moordyn/src/MoorDyn.f90
@@ -1703,7 +1703,22 @@ CONTAINS
                             CALL SetErrStat( ErrID_Fatal,  "No number provided for External Load "//trim(Num2LStr(l))//" Body attachment.", ErrStat, ErrMsg, RoutineName )
                                return
                          END IF
-                     ELSEIF (let1 == "ROD") THEN
+                     ELSEIF (let1 == "POINT" .OR. let1 == "P") THEN
+                        IF (len_trim(num1) > 0) THEN
+                           READ(num1, *) J   ! convert to int, representing parent body index
+                           IF ((J <= p%nBodies) .and. (J > 0)) THEN
+                              m%PointList(J)%Fext = m%PointList(J)%Fext + m%ExtLdList(l)%Fext
+                              m%PointList(J)%Blin = m%PointList(J)%Blin + m%ExtLdList(l)%Blin
+                              m%PointList(J)%Bquad = m%PointList(J)%Bquad + m%ExtLdList(l)%Bquad
+                           ELSE
+                              CALL SetErrStat( ErrID_Fatal,  "Body ID out of bounds for External Load "//trim(Num2LStr(l))//".", ErrStat, ErrMsg, RoutineName )
+                              return
+                           END IF
+                        ELSE
+                           CALL SetErrStat( ErrID_Fatal,  "No number provided for External Load "//trim(Num2LStr(l))//" Body attachment.", ErrStat, ErrMsg, RoutineName )
+                              return
+                        END IF
+                     ELSEIF (let1 == "ROD" .OR. let1 == "R") THEN
                         IF (len_trim(num1) > 0) THEN
                            READ(num1, *) J   ! convert to int, representing parent rod index
                            IF ((J <= p%nRods) .and. (J > 0)) THEN

--- a/modules/moordyn/src/MoorDyn_IO.f90
+++ b/modules/moordyn/src/MoorDyn_IO.f90
@@ -873,7 +873,7 @@ CONTAINS
       ! Open the output file, if necessary, and write the header
       !-------------------------------------------------------------------------------------------------
 
-      IF ( ALLOCATED( p%OutParam ) .AND. p%NumOuts > 0 ) THEN           ! Output has been requested so let's open an output file
+      IF ( ALLOCATED( p%OutParam ) .AND. p%NumOuts > 0  .AND. p%OutSwitch > 0) THEN           ! Output has been requested so let's open an output file
 
          ! Open the file for output
          OutFileName = TRIM(p%RootName)//'.out'
@@ -1580,7 +1580,7 @@ CONTAINS
          end if
          ! What the above does is say if ((dtOut==0) || (t >= (floor((t-dtC)/dtOut) + 1.0)*dtOut)), continue to writing files
 
-      if ( p%NumOuts > 0_IntKi ) then  
+      if ( p%NumOuts > 0_IntKi .and. p%MDUnOut > 0 ) then  
       
          ! Write the output parameters to the file
          Frmt = '(F10.4,'//TRIM(Int2LStr(p%NumOuts))//'(A1,ES15.7E2))'   ! should evenutally use user specified format?

--- a/modules/moordyn/src/MoorDyn_Point.f90
+++ b/modules/moordyn/src/MoorDyn_Point.f90
@@ -279,7 +279,13 @@ CONTAINS
          Point%M   (J,J) = Point%M   (J,J) + Point%pointV*p%rhoW*Point%pointCa;                               ! add added mass
 
       END DO
-      
+
+      ! Added user-defined external force and damping on point
+      Point%Fnet = Point%Fnet + Point%Fext
+      DO J = 1, 3
+         Point%Fnet(J) = Point%Fnet(J) - Point%Blin(J) * Point%rd(J) - Point%Bquad(J) * ABS(Point%rd(J)) * Point%rd(J)
+      END DO
+
       ! would this sub ever need to include the m*a inertial term?  Is it ever called for coupled points? <<<
 
    END SUBROUTINE Point_DoRHS

--- a/modules/moordyn/src/MoorDyn_Registry.txt
+++ b/modules/moordyn/src/MoorDyn_Registry.txt
@@ -193,6 +193,7 @@ typedef  ^            ^                DbKi               Dq           {:}{:}   
 typedef  ^            ^                DbKi               Ap           {:}{:}    -  -   "node added mass forcing (transverse)"  "[N]"
 typedef  ^            ^                DbKi               Aq           {:}{:}    -  -   "node added mass forcing (axial)"  "[N]"
 typedef  ^            ^                DbKi               B            {:}{:}    -  -   "node bottom contact force"  "[N]"
+typedef  ^            ^                DbKi               Bp           {:}{:}    -  -   "transverse damping force"  "[N]"
 typedef  ^            ^                DbKi               Fnet         {:}{:}    -  -   "total force on node"  "[N]"
 typedef  ^            ^                DbKi               M            {:}{:}{:} -  -   "node mass matrix"  "[kg]"
 typedef  ^            ^                DbKi               FextA        {3}       -  -   "external forces from attached lines on/about end A " -

--- a/modules/moordyn/src/MoorDyn_Registry.txt
+++ b/modules/moordyn/src/MoorDyn_Registry.txt
@@ -423,6 +423,7 @@ typedef   ^       ^                    DbKi                mc             -     
 typedef   ^       ^                    DbKi                cv             -     -    -   "saturated damping coefficient" "(-)"
 typedef   ^       ^                    IntKi        inertialF             -     0    -   "Indicates MoorDyn returning inertial moments for coupled 6DOF objects. 0: no, 1: yes, 2: yes with ramp to inertialF_rampT" - 
 typedef   ^       ^                    R8Ki         inertialF_rampT       -    30    -   "Ramp time for inertial forces" - 
+typedef   ^       ^                    IntKi               OutSwitch      -     1    -   "Switch to disable outputs when running with full OF. 0: no MD main outfile, 1: write MD main outfile" "(-)"
 # --- parameters for wave and current ---
 typedef   ^       ^                    IntKi        nxWave             -            -  -   "number of x wave grid points"            -
 typedef   ^       ^                    IntKi        nyWave             -            -  -   "number of y wave grid points"            -

--- a/modules/moordyn/src/MoorDyn_Registry.txt
+++ b/modules/moordyn/src/MoorDyn_Registry.txt
@@ -86,8 +86,8 @@ typedef  ^            ^                DbKi               Cdn            -      
 typedef  ^            ^                DbKi               Cdt            -       -  -   "tangential drag coefficient"
 typedef  ^            ^                DbKi               CdEnd          -       -  -   "drag coefficient for rod end"  "[-]"
 typedef  ^            ^                DbKi               CaEnd          -       -  -   "added mass coefficient for rod end"  "[-]"
-typedef  ^            ^                DbKi               LinDamp        -       -  -   "Linear damping, transverse damping for body element" "[N/(m/s)/m]"
-typedef  ^            ^                LOGICAL            isLinDamp      -       -  -   "Linear damping, transverse damping for body element is used" "-"
+typedef  ^            ^                DbKi               Blin        -       -  -   "Linear damping, transverse damping for rod element" "[N/(m/s)/m]"
+typedef  ^            ^                LOGICAL            isBlin      -       -  -   "Linear damping, transverse damping for rod element is used" "-"
 
 # this is the Body type, which holds data for each body object
 typedef  ^            MD_Body          IntKi              IdNum          -       -  -   "integer identifier of this Point"
@@ -170,8 +170,8 @@ typedef  ^            ^                DbKi               Cdn            -      
 typedef  ^            ^                DbKi               Cdt            -        -  -   ""  "[-]"
 typedef  ^            ^                DbKi               CdEnd          -       -  -   "drag coefficient for rod end"  "[-]"
 typedef  ^            ^                DbKi               CaEnd          -       -  -   "added mass coefficient for rod end"  "[-]"
-typedef  ^            ^                DbKi               LinDamp        -       -  -   "Linear damping, transverse damping for rod element" "[N/(m/s)/m]"
-typedef  ^            ^                LOGICAL            isLinDamp      -       -  -   "Linear damping, transverse damping for rod element is used" "-"
+typedef  ^            ^                DbKi               Blin        -       -  -   "Linear damping, transverse damping for rod element" "[N/(m/s)/m]"
+typedef  ^            ^                LOGICAL            isBlin      -       -  -   "Linear damping, transverse damping for rod element is used" "-"
 typedef  ^            ^                DbKi               time           -       -  -   "current time"         "[s]"
 typedef  ^            ^                DbKi               roll           -       -  -   "roll relative to vertical"         "[rad]"
 typedef  ^            ^                DbKi               pitch          -       -  -   "pitch relative to vertical"        "[rad]"

--- a/modules/moordyn/src/MoorDyn_Registry.txt
+++ b/modules/moordyn/src/MoorDyn_Registry.txt
@@ -142,6 +142,9 @@ typedef  ^            ^                DbKi               zeta           -      
 typedef  ^            ^                DbKi               PDyn         {:}       -  -   "water dynamic pressure at node"  "[Pa]"
 typedef  ^            ^                DbKi               Fnet           {3}     -  -   "total force on node (excluding inertial loads)"
 typedef  ^            ^                DbKi               M              {3}{3}  -  -   "node mass matrix, from attached lines"
+typedef  ^            ^                DbKi               Fext           {3}     -  -   "vector of user-defined external force on the body" [N]
+typedef  ^            ^                DbKi               Blin           {3}     -  -   "user-defined linear translational damping on the body" [N/(m/s)]
+typedef  ^            ^                DbKi               Bquad          {3}     -  -   "user-defined quadratic translational damping on the body" [N/(m/s)^2]
 
 # this is the Rod type, which holds data for each Rod object
 typedef  ^            MD_Rod           IntKi              IdNum         -        -  -   "integer identifier of this Line"

--- a/modules/moordyn/src/MoorDyn_Registry.txt
+++ b/modules/moordyn/src/MoorDyn_Registry.txt
@@ -86,8 +86,6 @@ typedef  ^            ^                DbKi               Cdn            -      
 typedef  ^            ^                DbKi               Cdt            -       -  -   "tangential drag coefficient"
 typedef  ^            ^                DbKi               CdEnd          -       -  -   "drag coefficient for rod end"  "[-]"
 typedef  ^            ^                DbKi               CaEnd          -       -  -   "added mass coefficient for rod end"  "[-]"
-typedef  ^            ^                DbKi               Blin        -       -  -   "Linear damping, transverse damping for rod element" "[N/(m/s)/m]"
-typedef  ^            ^                LOGICAL            isBlin      -       -  -   "Linear damping, transverse damping for rod element is used" "-"
 
 # this is the Body type, which holds data for each body object
 typedef  ^            MD_Body          IntKi              IdNum          -       -  -   "integer identifier of this Point"
@@ -170,8 +168,6 @@ typedef  ^            ^                DbKi               Cdn            -      
 typedef  ^            ^                DbKi               Cdt            -        -  -   ""  "[-]"
 typedef  ^            ^                DbKi               CdEnd          -       -  -   "drag coefficient for rod end"  "[-]"
 typedef  ^            ^                DbKi               CaEnd          -       -  -   "added mass coefficient for rod end"  "[-]"
-typedef  ^            ^                DbKi               Blin        -       -  -   "Linear damping, transverse damping for rod element" "[N/(m/s)/m]"
-typedef  ^            ^                LOGICAL            isBlin      -       -  -   "Linear damping, transverse damping for rod element is used" "-"
 typedef  ^            ^                DbKi               time           -       -  -   "current time"         "[s]"
 typedef  ^            ^                DbKi               roll           -       -  -   "roll relative to vertical"         "[rad]"
 typedef  ^            ^                DbKi               pitch          -       -  -   "pitch relative to vertical"        "[rad]"
@@ -194,6 +190,7 @@ typedef  ^            ^                DbKi               Ap           {:}{:}   
 typedef  ^            ^                DbKi               Aq           {:}{:}    -  -   "node added mass forcing (axial)"  "[N]"
 typedef  ^            ^                DbKi               B            {:}{:}    -  -   "node bottom contact force"  "[N]"
 typedef  ^            ^                DbKi               Bp           {:}{:}    -  -   "transverse damping force"  "[N]"
+typedef  ^            ^                DbKi               Bq           {:}{:}    -  -   "axial damping force"  "[N]"
 typedef  ^            ^                DbKi               Fnet         {:}{:}    -  -   "total force on node"  "[N]"
 typedef  ^            ^                DbKi               M            {:}{:}{:} -  -   "node mass matrix"  "[kg]"
 typedef  ^            ^                DbKi               FextA        {3}       -  -   "external forces from attached lines on/about end A " -
@@ -208,6 +205,10 @@ typedef  ^            ^                DbKi               Imat         {3}{3}   
 typedef  ^            ^                DbKi               OrMat        {3}{3}    -  -   "DCM for body orientation"
 typedef  ^            ^                IntKi              RodUnOut      -        -  -   "unit number of rod output file"
 typedef  ^            ^                DbKi               RodWrOutput  {:}       -  -   "one row of output data for this rod"
+typedef  ^            ^                DbKi               FextU        {3}       -  -   "vector of user-defined external force on the rod end A" [N]
+typedef  ^            ^                DbKi               Blin         {2}       -  -   "linear damping, transverse damping for rod element" "[N/(m/s)]"
+typedef  ^            ^                DbKi               Bquad        {2}       -  -   "quadratic damping, transverse damping for rod element" "[N/(m/s)^2]"
+
 
 
 # this is the Line type, which holds data for each line object

--- a/modules/moordyn/src/MoorDyn_Rod.f90
+++ b/modules/moordyn/src/MoorDyn_Rod.f90
@@ -82,8 +82,8 @@ CONTAINS
       Rod%Cdt   = RodProp%Cdt      
       Rod%CaEnd = RodProp%CaEnd      
       Rod%CdEnd = RodProp%CdEnd   
-      Rod%linDamp = RodProp%linDamp 
-      Rod%islinDamp = RodProp%islinDamp 
+      Rod%Blin = RodProp%Blin 
+      Rod%isBlin = RodProp%isBlin 
 
       ! allocate node positions and velocities (NOTE: these arrays start at ZERO)
       ALLOCATE(Rod%r(3, 0:N), Rod%rd(3, 0:N), STAT=ErrStat2);  if(AllocateFailed("")) return
@@ -763,7 +763,7 @@ CONTAINS
             MagVq = sqrt(SumSqVq)
 
             ! transverse and tangenential drag
-            Rod%Dp(:,I) = VOF * 0.5*p%rhoW*Rod%Cdn*    Rod%d* dL * MagVp * Vp   - Rod%linDamp * Vp_lin * dL  ! linear damping added 
+            Rod%Dp(:,I) = VOF * 0.5*p%rhoW*Rod%Cdn*    Rod%d* dL * MagVp * Vp - Rod%Blin * Vp_lin * dL  ! linear damping added 
             Rod%Dq(:,I) = 0.0_DbKi ! 0.25*p%rhoW*Rod%Cdt* Pi*Rod%d* dL * MagVq * Vq <<< should these axial side loads be included?
 
 

--- a/modules/moordyn/src/MoorDyn_Rod.f90
+++ b/modules/moordyn/src/MoorDyn_Rod.f90
@@ -101,7 +101,7 @@ CONTAINS
 
       ! allocate node force vectors
       ALLOCATE(Rod%W(3, 0:N), Rod%Bo(3, 0:N), Rod%Dp(3, 0:N), Rod%Dq(3, 0:N), Rod%Ap(3, 0:N), &
-         Rod%Aq(3, 0:N), Rod%Pd(3, 0:N), Rod%B(3, 0:N), Rod%Fnet(3, 0:N), STAT=ErrStat2)
+         Rod%Aq(3, 0:N), Rod%Pd(3, 0:N), Rod%B(3, 0:N), Rod%Bp(3, 0:N), Rod%Fnet(3, 0:N), STAT=ErrStat2)
          if(AllocateFailed("Rod: force arrays")) return
       
       ! allocate mass and inverse mass matrices for each node (including ends)
@@ -763,10 +763,11 @@ CONTAINS
             MagVq = sqrt(SumSqVq)
 
             ! transverse and tangenential drag
-            Rod%Dp(:,I) = VOF * 0.5*p%rhoW*Rod%Cdn*    Rod%d* dL * MagVp * Vp - Rod%Blin * Vp_lin * dL  ! linear damping added 
+            Rod%Dp(:,I) = VOF * 0.5*p%rhoW*Rod%Cdn*    Rod%d* dL * MagVp * Vp 
             Rod%Dq(:,I) = 0.0_DbKi ! 0.25*p%rhoW*Rod%Cdt* Pi*Rod%d* dL * MagVq * Vq <<< should these axial side loads be included?
 
-
+            ! Transverse damping force
+            Rod%Bp(:,I) = -Rod%Blin * Vp_lin * dL  ! linear damping added. Quadratic damping tbd
 
             ! fluid acceleration components for current node
             aq = DOT_PRODUCT(Rod%Ud(:,I), Rod%q) * Rod%q  ! tangential component of fluid acceleration
@@ -803,6 +804,7 @@ CONTAINS
             Rod%Aq = 0.0_DbKi
             Rod%Pd = 0.0_DbKi
             Rod%B  = 0.0_DbKi
+            Rod%Bp = 0.0_DbKi
             
          END IF
          
@@ -873,7 +875,7 @@ CONTAINS
          ! ---------------------------- total forces for this node -----------------------------
          
          Rod%Fnet(:,I) = Rod%W(:,I) + Rod%Bo(:,I) + Rod%Dp(:,I) + Rod%Dq(:,I) &
-                         + Rod%Ap(:,I) + Rod%Aq(:,I) + Rod%Pd(:,I) + Rod%B(:,I)
+                         + Rod%Ap(:,I) + Rod%Aq(:,I) + Rod%Pd(:,I) + Rod%B(:,I) + Rod%Bp(:,I)
          
 
       END DO  ! I  - done looping through nodes

--- a/modules/moordyn/src/MoorDyn_Rod.f90
+++ b/modules/moordyn/src/MoorDyn_Rod.f90
@@ -765,9 +765,11 @@ CONTAINS
             Rod%Dq(:,I) = 0.0_DbKi ! 0.25*p%rhoW*Rod%Cdt* Pi*Rod%d* dL * MagVq * Vq <<< should these axial side loads be included?
 
             ! transverse and tangential damping force (note this is the force per node)
-            Rod%Bp(:,I) = (-Rod%Blin(1) * Vp_vel - Rod%Bquad(1) * ABS(Vp_vel) * Vp_vel) * dL / Rod%UnstrLen
-            Rod%Bq(:,I) = (-Rod%Blin(2) * Vq_vel - Rod%Bquad(2) * ABS(Vq_vel) * Vq_vel) * dL / Rod%UnstrLen
-
+            DO J = 1, 3
+               Rod%Bp(J,I) = (-Rod%Blin(1) * Vp_vel(J) - Rod%Bquad(1) * ABS(Vp_vel(J)) * Vp_vel(J)) * dL / Rod%UnstrLen
+               Rod%Bq(J,I) = (-Rod%Blin(2) * Vq_vel(J) - Rod%Bquad(2) * ABS(Vq_vel(J)) * Vq_vel(J)) * dL / Rod%UnstrLen
+            END DO
+         
             ! fluid acceleration components for current node
             aq = DOT_PRODUCT(Rod%Ud(:,I), Rod%q) * Rod%q  ! tangential component of fluid acceleration
             ap = Rod%Ud(:,I) - aq                         ! normal component of fluid acceleration

--- a/modules/moordyn/src/MoorDyn_Rod.f90
+++ b/modules/moordyn/src/MoorDyn_Rod.f90
@@ -82,8 +82,6 @@ CONTAINS
       Rod%Cdt   = RodProp%Cdt      
       Rod%CaEnd = RodProp%CaEnd      
       Rod%CdEnd = RodProp%CdEnd   
-      Rod%Blin = RodProp%Blin 
-      Rod%isBlin = RodProp%isBlin 
 
       ! allocate node positions and velocities (NOTE: these arrays start at ZERO)
       ALLOCATE(Rod%r(3, 0:N), Rod%rd(3, 0:N), STAT=ErrStat2);  if(AllocateFailed("")) return
@@ -101,7 +99,7 @@ CONTAINS
 
       ! allocate node force vectors
       ALLOCATE(Rod%W(3, 0:N), Rod%Bo(3, 0:N), Rod%Dp(3, 0:N), Rod%Dq(3, 0:N), Rod%Ap(3, 0:N), &
-         Rod%Aq(3, 0:N), Rod%Pd(3, 0:N), Rod%B(3, 0:N), Rod%Bp(3, 0:N), Rod%Fnet(3, 0:N), STAT=ErrStat2)
+         Rod%Aq(3, 0:N), Rod%Pd(3, 0:N), Rod%B(3, 0:N), Rod%Bp(3, 0:N), Rod%Bq(3, 0:N), Rod%Fnet(3, 0:N), STAT=ErrStat2)
          if(AllocateFailed("Rod: force arrays")) return
       
       ! allocate mass and inverse mass matrices for each node (including ends)
@@ -570,8 +568,8 @@ CONTAINS
       Real(DbKi)                 :: Mass_i(3,3)  ! mass from an attached line
 
      ! Linear damping, Front Energies, July 2024 
-     Real(DbKi)                 :: Vi_lin(3)            ! velocity induced by Rod Motion 
-     Real(DbKi)                 :: Vp_lin(3), Vq_lin(3) ! transverse and axial components of Rod motion at a given node     
+     Real(DbKi)                 :: Vi_vel(3)            ! velocity induced by Rod Motion 
+     Real(DbKi)                 :: Vp_vel(3), Vq_vel(3) ! transverse and axial components of Rod motion at a given node     
 
       ! used in lumped 6DOF calculations:
       Real(DbKi)                 :: rRel(  3)              ! relative position of each node i from rRef      
@@ -742,7 +740,7 @@ CONTAINS
             !relative flow velocities
             DO J = 1, 3
                Vi(J) = Rod%U(J,I) - Rod%rd(J,I)                               ! relative flow velocity over node -- this is where wave velicites would be added
-               Vi_lin(J) = Rod%rd(J,I)                                        ! linear damping
+               Vi_vel(J) = Rod%rd(J,I)                                        ! relative node velocity
             END DO
 
             ! decomponse relative flow into components
@@ -754,9 +752,9 @@ CONTAINS
                SumSqVq = SumSqVq + Vq(J)*Vq(J)
                SumSqVp = SumSqVp + Vp(J)*Vp(J)
 
-               ! linear damping 
-               Vq_lin(J) = DOT_PRODUCT( Vi_lin , Rod%q ) * Rod%q(J)     ! tangential relative Rod velocity component
-               Vp_lin(J) = Vi_lin(J) - Vq_lin(J)                        ! transverse relative Rod velocity component
+               ! relative velocity for external damping 
+               Vq_vel(J) = DOT_PRODUCT( Vi_vel , Rod%q ) * Rod%q(J)     ! tangential relative node velocity component
+               Vp_vel(J) = Vi_vel(J) - Vq_vel(J)                        ! transverse relative node velocity component
 
             END DO
             MagVp = sqrt(SumSqVp)                                       ! get magnitudes of flow components
@@ -766,8 +764,9 @@ CONTAINS
             Rod%Dp(:,I) = VOF * 0.5*p%rhoW*Rod%Cdn*    Rod%d* dL * MagVp * Vp 
             Rod%Dq(:,I) = 0.0_DbKi ! 0.25*p%rhoW*Rod%Cdt* Pi*Rod%d* dL * MagVq * Vq <<< should these axial side loads be included?
 
-            ! Transverse damping force
-            Rod%Bp(:,I) = -Rod%Blin * Vp_lin * dL  ! linear damping added. Quadratic damping tbd
+            ! transverse and tangential damping force (note this is the force per node)
+            Rod%Bp(:,I) = (-Rod%Blin(1) * Vp_vel - Rod%Bquad(1) * ABS(Vp_vel) * Vp_vel) * dL / Rod%UnstrLen
+            Rod%Bq(:,I) = (-Rod%Blin(2) * Vq_vel - Rod%Bquad(2) * ABS(Vq_vel) * Vq_vel) * dL / Rod%UnstrLen
 
             ! fluid acceleration components for current node
             aq = DOT_PRODUCT(Rod%Ud(:,I), Rod%q) * Rod%q  ! tangential component of fluid acceleration
@@ -805,6 +804,7 @@ CONTAINS
             Rod%Pd = 0.0_DbKi
             Rod%B  = 0.0_DbKi
             Rod%Bp = 0.0_DbKi
+            Rod%Bq = 0.0_DbKi
             
          END IF
          
@@ -875,7 +875,7 @@ CONTAINS
          ! ---------------------------- total forces for this node -----------------------------
          
          Rod%Fnet(:,I) = Rod%W(:,I) + Rod%Bo(:,I) + Rod%Dp(:,I) + Rod%Dq(:,I) &
-                         + Rod%Ap(:,I) + Rod%Aq(:,I) + Rod%Pd(:,I) + Rod%B(:,I) + Rod%Bp(:,I)
+                         + Rod%Ap(:,I) + Rod%Aq(:,I) + Rod%Pd(:,I) + Rod%B(:,I) + Rod%Bp(:,I) + Rod%Bq(:,I)
          
 
       END DO  ! I  - done looping through nodes
@@ -982,6 +982,9 @@ CONTAINS
       ! add centripetal force/moment, gyroscopic moment, and any moments applied from lines at either end (might be zero)
       Rod%F6net(1:3) = Rod%F6net(1:3) + Fcentripetal 
       Rod%F6net(4:6) = Rod%F6net(4:6) + Mcentripetal + Rod%Mext
+
+      ! add in user defined external forces to end A
+      Rod%F6net(1:3) = Rod%F6net(1:3) + Rod%FextU
             
       ! Note: F6net saves the Rod's net forces and moments (excluding inertial ones) for use in later output
       !       (this is what the rod will apply to whatever it's attached to, so should be zero moments if pinned).

--- a/modules/moordyn/src/MoorDyn_Types.f90
+++ b/modules/moordyn/src/MoorDyn_Types.f90
@@ -460,6 +460,7 @@ IMPLICIT NONE
     REAL(DbKi)  :: cv = 0.0_R8Ki      !< saturated damping coefficient [(-)]
     INTEGER(IntKi)  :: inertialF = 0      !< Indicates MoorDyn returning inertial moments for coupled 6DOF objects. 0: no, 1: yes, 2: yes with ramp to inertialF_rampT [-]
     REAL(R8Ki)  :: inertialF_rampT = 30      !< Ramp time for inertial forces [-]
+    INTEGER(IntKi)  :: OutSwitch = 1      !< Switch to disable outputs when running with full OF. 0: no MD main outfile, 1: write MD main outfile [(-)]
     INTEGER(IntKi)  :: nxWave = 0_IntKi      !< number of x wave grid points [-]
     INTEGER(IntKi)  :: nyWave = 0_IntKi      !< number of y wave grid points [-]
     INTEGER(IntKi)  :: nzWave = 0_IntKi      !< number of z wave grid points [-]
@@ -3812,6 +3813,7 @@ subroutine MD_CopyParam(SrcParamData, DstParamData, CtrlCode, ErrStat, ErrMsg)
    DstParamData%cv = SrcParamData%cv
    DstParamData%inertialF = SrcParamData%inertialF
    DstParamData%inertialF_rampT = SrcParamData%inertialF_rampT
+   DstParamData%OutSwitch = SrcParamData%OutSwitch
    DstParamData%nxWave = SrcParamData%nxWave
    DstParamData%nyWave = SrcParamData%nyWave
    DstParamData%nzWave = SrcParamData%nzWave
@@ -4213,6 +4215,7 @@ subroutine MD_PackParam(RF, Indata)
    call RegPack(RF, InData%cv)
    call RegPack(RF, InData%inertialF)
    call RegPack(RF, InData%inertialF_rampT)
+   call RegPack(RF, InData%OutSwitch)
    call RegPack(RF, InData%nxWave)
    call RegPack(RF, InData%nyWave)
    call RegPack(RF, InData%nzWave)
@@ -4319,6 +4322,7 @@ subroutine MD_UnPackParam(RF, OutData)
    call RegUnpack(RF, OutData%cv); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%inertialF); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%inertialF_rampT); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%OutSwitch); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%nxWave); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%nyWave); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%nzWave); if (RegCheckErr(RF, RoutineName)) return

--- a/modules/moordyn/src/MoorDyn_Types.f90
+++ b/modules/moordyn/src/MoorDyn_Types.f90
@@ -101,8 +101,8 @@ IMPLICIT NONE
     REAL(DbKi)  :: Cdt = 0.0_R8Ki      !< tangential drag coefficient [-]
     REAL(DbKi)  :: CdEnd = 0.0_R8Ki      !< drag coefficient for rod end [[-]]
     REAL(DbKi)  :: CaEnd = 0.0_R8Ki      !< added mass coefficient for rod end [[-]]
-    REAL(DbKi)  :: LinDamp = 0.0_R8Ki      !< Linear damping, transverse damping for body element [[N/(m/s)/m]]
-    LOGICAL  :: isLinDamp = .false.      !< Linear damping, transverse damping for body element is used [-]
+    REAL(DbKi)  :: Blin = 0.0_R8Ki      !< Linear damping, transverse damping for body element [[N/(m/s)/m]]
+    LOGICAL  :: isBlin = .false.      !< Linear damping, transverse damping for body element is used [-]
   END TYPE MD_RodProp
 ! =======================
 ! =========  MD_Body  =======
@@ -191,8 +191,8 @@ IMPLICIT NONE
     REAL(DbKi)  :: Cdt = 0.0_R8Ki      !<  [[-]]
     REAL(DbKi)  :: CdEnd = 0.0_R8Ki      !< drag coefficient for rod end [[-]]
     REAL(DbKi)  :: CaEnd = 0.0_R8Ki      !< added mass coefficient for rod end [[-]]
-    REAL(DbKi)  :: LinDamp = 0.0_R8Ki      !< Linear damping, transverse damping for rod element [[N/(m/s)/m]]
-    LOGICAL  :: isLinDamp = .false.      !< Linear damping, transverse damping for rod element is used [-]
+    REAL(DbKi)  :: Blin = 0.0_R8Ki      !< Linear damping, transverse damping for rod element [[N/(m/s)/m]]
+    LOGICAL  :: isBlin = .false.      !< Linear damping, transverse damping for rod element is used [-]
     REAL(DbKi)  :: time = 0.0_R8Ki      !< current time [[s]]
     REAL(DbKi)  :: roll = 0.0_R8Ki      !< roll relative to vertical [[rad]]
     REAL(DbKi)  :: pitch = 0.0_R8Ki      !< pitch relative to vertical [[rad]]
@@ -819,8 +819,8 @@ subroutine MD_CopyRodProp(SrcRodPropData, DstRodPropData, CtrlCode, ErrStat, Err
    DstRodPropData%Cdt = SrcRodPropData%Cdt
    DstRodPropData%CdEnd = SrcRodPropData%CdEnd
    DstRodPropData%CaEnd = SrcRodPropData%CaEnd
-   DstRodPropData%LinDamp = SrcRodPropData%LinDamp
-   DstRodPropData%isLinDamp = SrcRodPropData%isLinDamp
+   DstRodPropData%Blin = SrcRodPropData%Blin
+   DstRodPropData%isBlin = SrcRodPropData%isBlin
 end subroutine
 
 subroutine MD_DestroyRodProp(RodPropData, ErrStat, ErrMsg)
@@ -847,8 +847,8 @@ subroutine MD_PackRodProp(RF, Indata)
    call RegPack(RF, InData%Cdt)
    call RegPack(RF, InData%CdEnd)
    call RegPack(RF, InData%CaEnd)
-   call RegPack(RF, InData%LinDamp)
-   call RegPack(RF, InData%isLinDamp)
+   call RegPack(RF, InData%Blin)
+   call RegPack(RF, InData%isBlin)
    if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
@@ -867,8 +867,8 @@ subroutine MD_UnPackRodProp(RF, OutData)
    call RegUnpack(RF, OutData%Cdt); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%CdEnd); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%CaEnd); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%LinDamp); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%isLinDamp); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%Blin); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%isBlin); if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
 subroutine MD_CopyBody(SrcBodyData, DstBodyData, CtrlCode, ErrStat, ErrMsg)
@@ -1151,8 +1151,8 @@ subroutine MD_CopyRod(SrcRodData, DstRodData, CtrlCode, ErrStat, ErrMsg)
    DstRodData%Cdt = SrcRodData%Cdt
    DstRodData%CdEnd = SrcRodData%CdEnd
    DstRodData%CaEnd = SrcRodData%CaEnd
-   DstRodData%LinDamp = SrcRodData%LinDamp
-   DstRodData%isLinDamp = SrcRodData%isLinDamp
+   DstRodData%Blin = SrcRodData%Blin
+   DstRodData%isBlin = SrcRodData%isBlin
    DstRodData%time = SrcRodData%time
    DstRodData%roll = SrcRodData%roll
    DstRodData%pitch = SrcRodData%pitch
@@ -1494,8 +1494,8 @@ subroutine MD_PackRod(RF, Indata)
    call RegPack(RF, InData%Cdt)
    call RegPack(RF, InData%CdEnd)
    call RegPack(RF, InData%CaEnd)
-   call RegPack(RF, InData%LinDamp)
-   call RegPack(RF, InData%isLinDamp)
+   call RegPack(RF, InData%Blin)
+   call RegPack(RF, InData%isBlin)
    call RegPack(RF, InData%time)
    call RegPack(RF, InData%roll)
    call RegPack(RF, InData%pitch)
@@ -1566,8 +1566,8 @@ subroutine MD_UnPackRod(RF, OutData)
    call RegUnpack(RF, OutData%Cdt); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%CdEnd); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%CaEnd); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%LinDamp); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%isLinDamp); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%Blin); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%isBlin); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%time); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%roll); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%pitch); if (RegCheckErr(RF, RoutineName)) return

--- a/modules/moordyn/src/MoorDyn_Types.f90
+++ b/modules/moordyn/src/MoorDyn_Types.f90
@@ -161,6 +161,9 @@ IMPLICIT NONE
     REAL(DbKi) , DIMENSION(:), ALLOCATABLE  :: PDyn      !< water dynamic pressure at node [[Pa]]
     REAL(DbKi) , DIMENSION(1:3)  :: Fnet = 0.0_R8Ki      !< total force on node (excluding inertial loads) [-]
     REAL(DbKi) , DIMENSION(1:3,1:3)  :: M = 0.0_R8Ki      !< node mass matrix, from attached lines [-]
+    REAL(DbKi) , DIMENSION(1:3)  :: Fext = 0.0_R8Ki      !< vector of user-defined external force on the body [[N]]
+    REAL(DbKi) , DIMENSION(1:3)  :: Blin = 0.0_R8Ki      !< user-defined linear translational damping on the body [[N/(m/s)]]
+    REAL(DbKi) , DIMENSION(1:3)  :: Bquad = 0.0_R8Ki      !< user-defined quadratic translational damping on the body [[N/(m/s)^2]]
   END TYPE MD_Point
 ! =======================
 ! =========  MD_Rod  =======
@@ -1034,6 +1037,9 @@ subroutine MD_CopyPoint(SrcPointData, DstPointData, CtrlCode, ErrStat, ErrMsg)
    end if
    DstPointData%Fnet = SrcPointData%Fnet
    DstPointData%M = SrcPointData%M
+   DstPointData%Fext = SrcPointData%Fext
+   DstPointData%Blin = SrcPointData%Blin
+   DstPointData%Bquad = SrcPointData%Bquad
 end subroutine
 
 subroutine MD_DestroyPoint(PointData, ErrStat, ErrMsg)
@@ -1076,6 +1082,9 @@ subroutine MD_PackPoint(RF, Indata)
    call RegPackAlloc(RF, InData%PDyn)
    call RegPack(RF, InData%Fnet)
    call RegPack(RF, InData%M)
+   call RegPack(RF, InData%Fext)
+   call RegPack(RF, InData%Blin)
+   call RegPack(RF, InData%Bquad)
    if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
@@ -1110,6 +1119,9 @@ subroutine MD_UnPackPoint(RF, OutData)
    call RegUnpackAlloc(RF, OutData%PDyn); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%Fnet); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%M); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%Fext); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%Blin); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%Bquad); if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
 subroutine MD_CopyRod(SrcRodData, DstRodData, CtrlCode, ErrStat, ErrMsg)


### PR DESCRIPTION
As discussed, here is the PR. 

Note rods now have axial damping, and use the same format at bodies. I have not tested this beyond compiling and reading in an example input file: 


```
---------------------- EXTERNAL LOADS --------------------------------
ID    Object      Force         Blin         Bquad          Local/Global
(#)   (name)      (N)           (Ns/m)       (Ns^2/m^2)         (-)
1     Body1      1.0|2.0|3.0   4.0|5.0|6.0   7.0|8.0|9.0         G
2     Rod1       0.1|0.2|0.3   0.4|0.5       0.4|0.5             L
```

I left a few TODOs in MoorDyn.f90 that we will need to address too